### PR TITLE
feat(migration): add XML files to track migration states for various components

### DIFF
--- a/.idea/copilot.data.migration.agent.xml
+++ b/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask.xml
+++ b/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.edit.xml
+++ b/.idea/copilot.data.migration.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EditMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Feel free to register with a throw-away address and play – no credit card, no 
 
 > [!CAUTION]
 > The demo may be down periodically due to inactivity or maintenance. If you encounter issues, please try again later or deploy your own instance using the instructions below. Please don't rely on the demo for production use, as it may not always be available!
+>
+> Also, the demo instance is automatically powered off after periods of inactivity. If you find it down, please allow a few minutes for it to spin back up.
 
 ## ✨ Feature Highlights
 


### PR DESCRIPTION
This pull request primarily adds configuration files to mark the completion of migration states for various Copilot services in the project, and updates the documentation to clarify demo instance availability. These changes help keep the project setup and user expectations clear.

Configuration updates:

* Added `.idea/copilot.data.migration.agent.xml` to indicate that the agent migration status is set to "COMPLETED".
* Added `.idea/copilot.data.migration.ask.xml` to indicate that the ask migration status is set to "COMPLETED".
* Added `.idea/copilot.data.migration.edit.xml` to indicate that the edit migration status is set to "COMPLETED".

Documentation update:

* Updated the `README.md` to clarify that the demo instance is automatically powered off after inactivity and may take a few minutes to restart if accessed while down.