### PR TITLE
feat: enhance card content spacing for improved readability

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -581,7 +581,7 @@ export default function Landing() {
                   <div className="text-primary">{f.icon}</div>
                   <CardTitle>{f.title}</CardTitle>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="pt-3">
                   <p className="text-sm text-muted-foreground">{f.desc}</p>
                 </CardContent>
               </Card>
@@ -693,7 +693,7 @@ export default function Landing() {
                   </div>
                   <p className="text-sm text-muted-foreground">{p.desc}</p>
                 </CardHeader>
-                <CardContent className="space-y-4">
+                <CardContent className="space-y-4 pt-3">
                   <div className="text-2xl font-bold text-primary">
                     {p.stat}
                   </div>
@@ -758,7 +758,7 @@ export default function Landing() {
                   </div>
                   <p className="text-sm text-muted-foreground">{p.desc}</p>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="pt-3">
                   <div className="text-lg font-semibold text-primary">
                     {p.stat}
                   </div>
@@ -821,7 +821,7 @@ export default function Landing() {
                   </div>
                   <CardTitle className="text-base">{pillar.title}</CardTitle>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="pt-3">
                   <p className="text-sm text-muted-foreground">{pillar.desc}</p>
                 </CardContent>
               </Card>
@@ -1210,7 +1210,7 @@ function UseCase({
         </div>
         <CardTitle>{h}</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-3">
+      <CardContent className="space-y-3 pt-3">
         <p className="text-sm text-muted-foreground text-center">{p}</p>
         <p className="text-xs text-muted-foreground text-center">{d}</p>
       </CardContent>


### PR DESCRIPTION
This pull request makes minor UI improvements to the `Landing` and `UseCase` components in `web/pages/index.tsx`. The main change is the addition of consistent padding (`pt-3`) to the top of each `CardContent`, which improves visual spacing and alignment across different card sections.

UI consistency improvements:

* Added `pt-3` padding to the top of `CardContent` in various card sections for better spacing in the `Landing` component. [[1]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87L584-R584) [[2]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87L696-R696) [[3]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87L761-R761) [[4]](diffhunk://#diff-24f1c21e9cead7a2a6d2c60c350f5eab687aac48ff32ecb6e03237512e306c87L824-R824)
* Added `pt-3` padding to the top of `CardContent` in the `UseCase` component for improved alignment.