### PR TITLE
feat: enhance footer icons size for improved visibility

### DIFF
--- a/web/components/Footer.tsx
+++ b/web/components/Footer.tsx
@@ -44,7 +44,7 @@ export default function Footer() {
             </div>
 
             <div className="surface-muted flex items-center gap-3 px-4 py-3">
-              <ShieldCheck className="h-5 w-5 text-primary" />
+              <ShieldCheck className="h-6 w-6 shrink-0 text-primary" />
               <p className="text-sm text-muted-foreground">
                 Built for modern teams that need reliable redirects and readable
                 campaign intelligence.
@@ -115,7 +115,7 @@ export default function Footer() {
               ))}
             </div>
             <div className="surface-muted flex items-start gap-3 px-4 py-3">
-              <FileText className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+              <FileText className="mt-0.5 h-6 w-6 shrink-0 text-primary" />
               <p className="text-sm text-muted-foreground">
                 Product-specific legal pages covering redirects, analytics, AI
                 summaries, and local browser storage.


### PR DESCRIPTION
This pull request makes minor visual adjustments to icons in the `Footer` component to improve consistency and readability.

* Increased the size of the `ShieldCheck` and `FileText` icons from 5x5/4x4 to 6x6 pixels and ensured they do not shrink, enhancing visibility and alignment in the footer. (`web/components/Footer.tsx`, [[1]](diffhunk://#diff-3c5c87a649c6daf75cd129aa0d7d23edc93f9e3af4822bb03c70d0e01bd5cc52L47-R47) [[2]](diffhunk://#diff-3c5c87a649c6daf75cd129aa0d7d23edc93f9e3af4822bb03c70d0e01bd5cc52L118-R118)